### PR TITLE
The Hack Foundation vs the Hack Foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ The Hack Foundation was founded in 2016 as the legal entity for [Hack Club](http
 
 In [2018](https://medium.com/hackclub/hack-club-bank-a-bank-for-student-hackers-e5d894ea5375), we built out a [financial platform/fiscal sponsor for our clubs called Hack Club Bank](https://hackclub.com/bank).
 
-By [2019](https://medium.com/hackclub/hack-club-bank-is-now-live-for-everyone-including-you-884f7f54836f), Hack Club Bank expanded to become the largest fiscal sponsor for teen-led projects in the world. From Hack Clubs, to hackathons, FRC teams, to Little League teams, hundreds of groups with annual budgets from $100 to $250k are powered by The Hack Foundation and our tools.
+By [2019](https://medium.com/hackclub/hack-club-bank-is-now-live-for-everyone-including-you-884f7f54836f), Hack Club Bank expanded to become the largest fiscal sponsor for teen-led projects in the world. From Hack Clubs, to hackathons, FRC teams, to Little League teams, hundreds of groups with annual budgets from $100 to $250k are powered by the Hack Foundation and our tools.
 
-Hack Club HQ ourselves [runs on The Hack Foundation's platforms](https://bank.hackclub.com/hq), and we want to continue doing so to make sure we invest in making it better.
+Hack Club HQ ourselves [runs on the Hack Foundation's platforms](https://bank.hackclub.com/hq), and we want to continue doing so to make sure we invest in making it better.
 
-Every year, tens of thousands of people are impacted by organizations operating under The Hack Foundation. Partnered organizations receive the benefits of 501(c)(3) nonprofit status, administrative and backoffice support, and financial oversight.
+Every year, tens of thousands of people are impacted by organizations operating under the Hack Foundation. Partnered organizations receive the benefits of 501(c)(3) nonprofit status, administrative and backoffice support, and financial oversight.

--- a/pages/index.js
+++ b/pages/index.js
@@ -157,8 +157,8 @@ see the source: https://github.com/hackclub/hackfoundation.org
     >
       <Meta
         as={Head}
-        name="The Hack Foundation"
-        title="The Hack Foundation"
+        name="Hack Foundation"
+        title="Hack Foundation"
         description="The Hack Foundation partners with over 330 non-profit organizations including Hack Clubs, hackathons, Little League teams, newspapers, and everything in between to act as their legal and financial entity."
         image="https://cloud-nhm79e8am-hack-club-bot.vercel.app/0screenshot_2021-12-16_at_21.01.41.png"
       />
@@ -185,7 +185,7 @@ see the source: https://github.com/hackclub/hackfoundation.org
             width: 'max-content'
           }}
         >
-          The Hack Foundation
+          Hack Foundation
         </Heading>
         <p className="mt-0" style={{ marginTop: '10px!important' }}>
           The Hack Foundation (EIN: 81-2908499) was founded in 2016 to serve as
@@ -197,7 +197,7 @@ see the source: https://github.com/hackclub/hackfoundation.org
           they wish they could have.
         </p>
         <p>
-          In 2018, The Hack Foundation expanded to act as a nonprofit{' '}
+          In 2018, the Hack Foundation expanded to act as a nonprofit{' '}
           <a
             target="_blank"
             className="a"
@@ -225,7 +225,7 @@ see the source: https://github.com/hackclub/hackfoundation.org
           >
             the largest high-school hackathon in Pennsylvania
           </a>{' '}
-          are fiscally sponsored by The Hack Foundation. Partnered organizations
+          are fiscally sponsored by the Hack Foundation. Partnered organizations
           receive the benefits of 501(c)(3) nonprofit status, administrative and
           backoffice support, financial oversight, and transparency tools.
         </p>


### PR DESCRIPTION
I'm a bit uncertain about this PR so here's some context:

There's been some confusion around "The Hack Foundation" because there happens to be another nonprofit called "[The Hack Foundation, Inc.](https://www.charitynavigator.org/ein/581802331)" in North Carolina which some people have almost accidentally donated to or referenced instead of "Hack Foundation" (Hack Club's legal entity).

The proposed change that I think may possibly help lessen the confusion a little:
This PR makes the "the" in "The Hack Foundation" lowercase where appropriate so that people don't mistake that as a part of the organization name.

https://hackclub.slack.com/archives/GBXBFEED9/p1644815143172779